### PR TITLE
Make Zoom in/out speed relative to current zoom

### DIFF
--- a/Frames.xml
+++ b/Frames.xml
@@ -14,5 +14,20 @@
         </Anchors>
     </ScrollFrame>
 
+    <!-- Templates -->
+    <Slider name="MagnifySliderTemplate" inherits="OptionsSliderTemplate" virtual="true">
+        <Size x="250" y="17"/>
+        <Layers>
+            <Layer level="ARTWORK">
+                <FontString name="$parentCurrentValueText" inherits="GameFontNormalSmall">
+                    <Anchors>
+                        <Anchor point="BOTTOM">
+                            <Offset x="0" y="-8"/>
+                        </Anchor>
+                    </Anchors>
+                </FontString>
+            </Layer>
+        </Layers>
+    </Slider>
 
 </Ui>

--- a/Main.lua
+++ b/Main.lua
@@ -2,11 +2,9 @@ local ADDON_NAME, Magnify = ...
 
 -- Constants
 Magnify.MIN_ZOOM = 1.0
-Magnify.MAX_ZOOM = 4.0
-Magnify.ZOOM_STEP = 0.2
 
 Magnify.MINIMODE_MIN_ZOOM = 1.0
-Magnify.MINIMODE_MAX_ZOOM = 10.0
+Magnify.MINIMODE_MAX_ZOOM = 3.0
 Magnify.MINIMODE_ZOOM_STEP = 0.1
 
 Magnify.WORLDMAP_POI_MIN_X = 12
@@ -27,6 +25,8 @@ Magnify.PreviousState = {
 MagnifyOptions = {
     enablePersistZoom = false,
     enableOldPartyIcons = false,
+    maxZoom = Magnify.MAXZOOM_DEFAULT,
+    zoomStep = Magnify.ZOOMSTEP_DEFAULT,
 }
 
 local function updatePointRelativeTo(frame, newRelativeFrame)
@@ -529,9 +529,9 @@ function Magnify.WorldMapScrollFrame_OnMouseWheel()
 
     local oldScale = WorldMapDetailFrame:GetScale()
     local newScale
-    newScale = oldScale + arg1 * Magnify.ZOOM_STEP
+    newScale = oldScale * (1.0 + arg1 * MagnifyOptions.zoomStep)
     newScale = max(Magnify.MIN_ZOOM, newScale)
-    newScale = min(Magnify.MAX_ZOOM, newScale)
+    newScale = min(MagnifyOptions.maxZoom, newScale)
 
     Magnify.SetDetailFrameScale(newScale)
 
@@ -606,6 +606,12 @@ function Magnify.CreateClassColorIcon(partyMemberFrame)
 end
 
 function Magnify.OnFirstLoad()
+    -- Make sure all settings got initalized
+    MagnifyOptions.enablePersistZoom = MagnifyOptions.enablePersistZoom or Magnify.ENABLEPERSISTZOOM_DEFAULT
+    MagnifyOptions.enableOldPartyIcons = MagnifyOptions.enableOldPartyIcons or Magnify.ENABLEOLDPARTYICONS_DEFAULT
+    MagnifyOptions.maxZoom = MagnifyOptions.maxZoom or Magnify.MAXZOOM_DEFAULT
+    MagnifyOptions.zoomStep = MagnifyOptions.zoomStep or Magnify.ZOOMSTEP_DEFAULT
+
     WorldMapScrollFrame:SetScrollChild(WorldMapDetailFrame)
     WorldMapScrollFrame:SetScript("OnMouseWheel", Magnify.WorldMapScrollFrame_OnMouseWheel)
     WorldMapButton:SetScript("OnMouseDown", Magnify.WorldMapButton_OnMouseDown)

--- a/Options.lua
+++ b/Options.lua
@@ -1,5 +1,19 @@
 local ADDON_NAME, Magnify = ...
 
+-- Constants
+Magnify.ENABLEPERSISTZOOM_DEFAULT = false
+Magnify.ENABLEOLDPARTYICONS_DEFAULT = false
+
+Magnify.MAXZOOM_DEFAULT = 4.0
+Magnify.MAXZOOM_SLIDER_MIN = 2.0
+Magnify.MAXZOOM_SLIDER_MAX = 10.0
+Magnify.MAXZOOM_SLIDER_STEP = 0.5
+
+Magnify.ZOOMSTEP_DEFAULT = 0.1
+Magnify.ZOOMSTEP_SLIDER_MIN = 0.01
+Magnify.ZOOMSTEP_SLIDER_MAX = 0.5
+Magnify.ZOOMSTEP_SLIDER_STEP = 0.01
+
 local panel = CreateFrame("Frame", nil, InterfaceOptionsFramePanelContainer)
 panel.name = ADDON_NAME
 InterfaceOptions_AddCategory(panel)
@@ -20,6 +34,24 @@ panel.EnableOldPartyIcons.tooltip = "Tick to disable the colored party icons on 
 _G[panel.EnableOldPartyIcons:GetName() .. "Text"]:SetText("Uncolored party icons");
 panel.EnableOldPartyIcons:SetPoint("TOPLEFT", panel.EnablePersistZoom, "BOTTOMLEFT", 0, 0)
 
+panel.MaxZoom = CreateFrame("Slider", "MagnifyOptionsMaxZoom", panel, 
+    "MagnifySliderTemplate");
+panel.MaxZoom:SetMinMaxValues(Magnify.MAXZOOM_SLIDER_MIN, Magnify.MAXZOOM_SLIDER_MAX);
+panel.MaxZoom:SetValueStep(Magnify.MAXZOOM_SLIDER_STEP);
+_G[panel.MaxZoom:GetName() .. "Text"]:SetText("Maximum Zoom");
+_G[panel.MaxZoom:GetName() .. "Low"]:SetText(Magnify.MAXZOOM_SLIDER_MIN);
+_G[panel.MaxZoom:GetName() .. "High"]:SetText(Magnify.MAXZOOM_SLIDER_MAX);
+panel.MaxZoom:SetPoint("TopLeft", panel.EnableOldPartyIcons, "BOTTOMLEFT", 0, -15);
+
+panel.ZoomStep = CreateFrame("Slider", "MagnifyOptionsZoomStep", panel, 
+    "MagnifySliderTemplate");
+panel.ZoomStep:SetMinMaxValues(Magnify.ZOOMSTEP_SLIDER_MIN, Magnify.ZOOMSTEP_SLIDER_MAX);
+panel.ZoomStep:SetValueStep(Magnify.ZOOMSTEP_SLIDER_STEP);
+_G[panel.ZoomStep:GetName() .. "Text"]:SetText("Zoom Speed");
+_G[panel.ZoomStep:GetName() .. "Low"]:SetText(Magnify.ZOOMSTEP_SLIDER_MIN);
+_G[panel.ZoomStep:GetName() .. "High"]:SetText(Magnify.ZOOMSTEP_SLIDER_MAX);
+panel.ZoomStep:SetPoint("TopLeft", panel.MaxZoom, "BOTTOMLEFT", 0, -30);
+
 function Magnify.InitOptions()
     panel.EnablePersistZoom:SetChecked(MagnifyOptions.enablePersistZoom)
     panel.EnablePersistZoom:SetScript("OnClick", function()
@@ -37,6 +69,20 @@ function Magnify.InitOptions()
         else
             MagnifyOptions.enableOldPartyIcons = false
         end
+    end)
+
+    panel.MaxZoom:SetValue(MagnifyOptions.maxZoom or Magnify.MAXZOOM_DEFAULT)
+    _G[panel.MaxZoom:GetName() .. "CurrentValueText"]:SetFormattedText("%.2f", panel.MaxZoom:GetValue())
+    panel.MaxZoom:SetScript("OnValueChanged", function()
+        MagnifyOptions.maxZoom = panel.MaxZoom:GetValue()
+        _G[panel.MaxZoom:GetName() .. "CurrentValueText"]:SetFormattedText("%.2f", panel.MaxZoom:GetValue())
+    end)
+
+    panel.ZoomStep:SetValue(MagnifyOptions.zoomStep or Magnify.ZOOMSTEP_DEFAULT)
+    _G[panel.ZoomStep:GetName() .. "CurrentValueText"]:SetFormattedText("%.2f", panel.ZoomStep:GetValue())
+    panel.ZoomStep:SetScript("OnValueChanged", function()
+        MagnifyOptions.zoomStep = panel.ZoomStep:GetValue()
+        _G[panel.ZoomStep:GetName() .. "CurrentValueText"]:SetFormattedText("%.2f", panel.ZoomStep:GetValue())
     end)
 end
 


### PR DESCRIPTION
Makes zoom steps be relative to the current zoom level, leading to a more consistent visual difference when zooming in/out. Also added options to set the max zoom level and zoom change per step.

<img width="773" height="625" alt="image" src="https://github.com/user-attachments/assets/8ec38f1c-8ebf-4062-bcf8-f2357b5298dd" />
