### PR TITLE
Fixed map frame being slightly offset when 'Movable World Map' is enabled

### DIFF
--- a/Frames.xml
+++ b/Frames.xml
@@ -6,11 +6,7 @@
             <AbsDimension x="1002" y="668" />
         </Size>
         <Anchors>
-            <Anchor point="TOPLEFT" relativePoint="TOP" relativeTo="WorldMapPositioningGuide">
-                <Offset>
-                    <AbsDimension x="-726" y="-99"/>
-                </Offset>
-            </Anchor>
+            <Anchor point="TOPLEFT" relativePoint="TOPLEFT" relativeTo="WorldMapPositioningGuide"/>
         </Anchors>
     </ScrollFrame>
 

--- a/Magnify-WotLK.toc
+++ b/Magnify-WotLK.toc
@@ -1,7 +1,7 @@
 ## Interface: 30300
 ## Title: Magnify |cff1784d1(WotLK)|r
 ## Notes: World Map Zoom Addon for 3.3.5a
-## Version: 1.4.1
+## Version: 1.4.3
 ## Author: rissole
 ## SavedVariables: MagnifyOptions
 

--- a/Main.lua
+++ b/Main.lua
@@ -213,16 +213,25 @@ function Magnify.SetupWorldMapFrame()
         WorldMapScrollFrame:SetPoint("TOPLEFT", WorldMapPositioningGuide, "TOP", -726, -99);
         WorldMapTrackQuest:SetPoint("BOTTOMLEFT", WorldMapPositioningGuide, "BOTTOMLEFT", 8, 4);
     elseif (WORLDMAP_SETTINGS.size == WORLDMAP_WINDOWED_SIZE) then
-        if (WORLDMAP_SETTINGS.advanced) then
-            WorldMapScrollFrame:SetPoint("TOPLEFT", 19, -42); 
-        else
-            WorldMapScrollFrame:SetPoint("TOPLEFT", 37, -66);
-        end
         WorldMapTrackQuest:SetPoint("BOTTOMLEFT", WorldMapPositioningGuide, "BOTTOMLEFT", 16, -9);
 
         WorldMapFrame:SetPoint("TOPLEFT", WorldMapScreenAnchor, 0, 0);
         WorldMapFrame:SetScale(WorldMapScreenAnchor.preferredMinimodeScale);
         WorldMapFrame:SetMovable("true");
+        WorldMapTitleButton:Show()
+        WorldMapTitleButton:ClearAllPoints()
+        WorldMapFrameTitle:Show()
+        WorldMapFrameTitle:ClearAllPoints();
+        WorldMapFrameTitle:SetPoint("CENTER", WorldMapTitleButton, "CENTER", 32, 0)
+
+        if (WORLDMAP_SETTINGS.advanced) then
+            WorldMapScrollFrame:SetPoint("TOPLEFT", 19, -42);
+            WorldMapTitleButton:SetPoint("TOPLEFT", WorldMapFrame, "TOPLEFT", 13, 0)
+        else
+            WorldMapScrollFrame:SetPoint("TOPLEFT", 37, -66);
+            WorldMapTitleButton:SetPoint("TOPLEFT", WorldMapFrame, "TOPLEFT", 13, -14)
+        end
+
     else
         WorldMapScrollFrame:SetPoint("TOPLEFT", WorldMapPositioningGuide, "TOPLEFT", 11, -70.5);
         WorldMapTrackQuest:SetPoint("BOTTOMLEFT", WorldMapPositioningGuide, "BOTTOMLEFT", 16, -9);

--- a/Main.lua
+++ b/Main.lua
@@ -213,18 +213,16 @@ function Magnify.SetupWorldMapFrame()
         WorldMapScrollFrame:SetPoint("TOPLEFT", WorldMapPositioningGuide, "TOP", -726, -99);
         WorldMapTrackQuest:SetPoint("BOTTOMLEFT", WorldMapPositioningGuide, "BOTTOMLEFT", 8, 4);
     elseif (WORLDMAP_SETTINGS.size == WORLDMAP_WINDOWED_SIZE) then
-        WorldMapScrollFrame:SetPoint("TOPLEFT", WorldMapPositioningGuide, "TOPLEFT", 18, -43);
+        if (WORLDMAP_SETTINGS.advanced) then
+            WorldMapScrollFrame:SetPoint("TOPLEFT", 19, -42); 
+        else
+            WorldMapScrollFrame:SetPoint("TOPLEFT", 37, -66);
+        end
         WorldMapTrackQuest:SetPoint("BOTTOMLEFT", WorldMapPositioningGuide, "BOTTOMLEFT", 16, -9);
 
         WorldMapFrame:SetPoint("TOPLEFT", WorldMapScreenAnchor, 0, 0);
         WorldMapFrame:SetScale(WorldMapScreenAnchor.preferredMinimodeScale);
         WorldMapFrame:SetMovable("true");
-        WorldMapTitleButton:Show()
-        WorldMapTitleButton:ClearAllPoints()
-        WorldMapTitleButton:SetPoint("TOPLEFT", WorldMapFrame, "TOPLEFT", 13, 0)
-        WorldMapFrameTitle:Show()
-        WorldMapFrameTitle:ClearAllPoints();
-        WorldMapFrameTitle:SetPoint("CENTER", WorldMapTitleButton, "CENTER", 32, 0)
     else
         WorldMapScrollFrame:SetPoint("TOPLEFT", WorldMapPositioningGuide, "TOPLEFT", 11, -70.5);
         WorldMapTrackQuest:SetPoint("BOTTOMLEFT", WorldMapPositioningGuide, "BOTTOMLEFT", 16, -9);

--- a/Main.lua
+++ b/Main.lua
@@ -213,7 +213,7 @@ function Magnify.SetupWorldMapFrame()
         WorldMapScrollFrame:SetPoint("TOPLEFT", WorldMapPositioningGuide, "TOP", -726, -99);
         WorldMapTrackQuest:SetPoint("BOTTOMLEFT", WorldMapPositioningGuide, "BOTTOMLEFT", 8, 4);
     elseif (WORLDMAP_SETTINGS.size == WORLDMAP_WINDOWED_SIZE) then
-        WorldMapScrollFrame:SetPoint("TOPLEFT", 37, -66);
+        WorldMapScrollFrame:SetPoint("TOPLEFT", WorldMapPositioningGuide, "TOPLEFT", 18, -43);
         WorldMapTrackQuest:SetPoint("BOTTOMLEFT", WorldMapPositioningGuide, "BOTTOMLEFT", 16, -9);
 
         WorldMapFrame:SetPoint("TOPLEFT", WorldMapScreenAnchor, 0, 0);
@@ -221,12 +221,12 @@ function Magnify.SetupWorldMapFrame()
         WorldMapFrame:SetMovable("true");
         WorldMapTitleButton:Show()
         WorldMapTitleButton:ClearAllPoints()
-        WorldMapTitleButton:SetPoint("TOPLEFT", WorldMapFrame, "TOPLEFT", 13, -13)
+        WorldMapTitleButton:SetPoint("TOPLEFT", WorldMapFrame, "TOPLEFT", 13, 0)
         WorldMapFrameTitle:Show()
         WorldMapFrameTitle:ClearAllPoints();
         WorldMapFrameTitle:SetPoint("CENTER", WorldMapTitleButton, "CENTER", 32, 0)
     else
-        WorldMapScrollFrame:SetPoint("TOPLEFT", WorldMapPositioningGuide, "TOP", -502, -69);
+        WorldMapScrollFrame:SetPoint("TOPLEFT", WorldMapPositioningGuide, "TOPLEFT", 11, -70.5);
         WorldMapTrackQuest:SetPoint("BOTTOMLEFT", WorldMapPositioningGuide, "BOTTOMLEFT", 16, -9);
     end
 


### PR DESCRIPTION
This fixes the windowed world map frame position so that it fits within the border.

I've only tested this on Epoch so I don't know if this was an Epoch-only bug.

Before: 
<img width="1005" height="744" alt="image" src="https://github.com/user-attachments/assets/c2d0b163-f4f9-4d62-a915-5f6114be57a5" />




After: 
<img width="995" height="735" alt="image" src="https://github.com/user-attachments/assets/6a59ccab-d4e0-42fe-81c8-9488b2177cb2" />
